### PR TITLE
feat: add debug_traceTransaction test

### DIFF
--- a/flood/tests/equality_tests/equality_test_sets.py
+++ b/flood/tests/equality_tests/equality_test_sets.py
@@ -277,4 +277,25 @@ def get_trace_equality_tests(
             ],
             {},
         ),
+        (
+            'debug_traceTransaction',
+            ctc.rpc.construct_debug_trace_transaction,
+            [
+                '0xd01212e8ab48d2fd2ea9c4f33f8670fd1cf0cfb09d2e3c6ceddfaf54152386e5'
+            ],
+            # we're enabling memory by default to unify behaviour across clients
+            {
+               'trace_opts': {
+                    'enableMemory': True
+                }
+            },
+        ),
+        # (
+        #     'debug_traceBlockByNumber',
+        #     ctc.rpc.construct_debug_trace_block_by_number,
+        #     [],
+        #     {
+        #         'block_number': block_number,    
+        #     },
+        # )
     ]


### PR DESCRIPTION
blocked by https://github.com/checkthechain/checkthechain/pull/69

`block` variant is currently disabled because it takes a while

sends:
> {'jsonrpc': '2.0', 'method': 'debug_traceTransaction', 'params': ['0xd01212e8ab48d2fd2ea9c4f33f8670fd1cf0cfb09d2e3c6ceddfaf54152386e5', {}], 'id': 390916859657650016}

 with https://github.com/checkthechain/checkthechain/pull/69