### PR TITLE
only split name and url on the first '='

### DIFF
--- a/flood/user_io/inputs.py
+++ b/flood/user_io/inputs.py
@@ -89,7 +89,7 @@ def parse_node(
     elif isinstance(node, str):
         # parse name
         if '=' in node:
-            name, url = node.split('=')
+            name, url = node.split('=', 1)
         else:
             name = node
             url = node


### PR DESCRIPTION
this allows for providers that use url parameters, e.g. node1=https://provider.com/eth?authKey=xxx