### PR TITLE
fix pyproject.toml dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,9 @@ dependencies = [
     'matplotlib >= 3.7.1, <4',
     'paradigm-data-portal >= 0.2.2, <0.3',
     'checkthechain >= 0.3.9, <0.4.0',
-    'nbconvert > 5.6.0, <6',
+    'nbconvert > 6, <7',
+    'ipython_genutils > 0.1, <1',
+    'ipykernel > 6, <7',
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Motivation

Fix broken run after fresh docker build.

## Solution

1) adding `ipykernel` fixed:
```
jupyter_client.kernelspec.NoSuchKernel: No such kernel named python3
```

2) adding `ipython_genutils` fixed:
```
ModuleNotFoundError: No module named 'ipython_genutils'
```

3) bumping the `nbconvert` version fixed:
```
ImportError: cannot import name 'contextfilter' from 'jinja2'
(/home/flood/.local/lib/python3.11/site-packages/jinja2/__init__.py)
```

This was tested within a Docker container, built with:
```
docker build --tag paradigmxyz/flood:latest .
```
Ran with:
```
docker run --rm --volume ${PWD}/output:/output paradigmxyz/flood:latest \
eth_getBlockByNumber NODE:8545 --output /output/
```

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/paradigmxyz/flood/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running ruff and building the
documentation.
-->


## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
