### PR TITLE
Add vegeta PATH in Docker, fix #24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-
 FROM python:3.11.3
 
 # create user
 ENV USERNAME="flood"
+ENV PATH="${PATH}:/home/${USERNAME}/bin"
 RUN adduser $USERNAME
 USER $USERNAME
 
@@ -18,15 +18,13 @@ RUN git clone https://github.com/checkthechain/checkthechain
 WORKDIR /home/$USERNAME/repos/checkthechain
 RUN pip install ./
 
-# # install vegeta
-RUN mkdir -p /home/$USERNAME/bin/vegeta
+# install vegeta
+RUN mkdir -p /home/$USERNAME/bin/vegeta_files
 WORKDIR /home/$USERNAME/bin/vegeta_files
 RUN wget https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz
 RUN tar xzf vegeta_12.8.4_linux_amd64.tar.gz
-WORKDIR /home/$USERNAME/bin/
 RUN ln -s /home/$USERNAME/bin/vegeta_files/vegeta /home/$USERNAME/bin/vegeta
 
 # run flood
 WORKDIR /home/$USERNAME
 ENTRYPOINT ["python", "-m", "flood"]
-


### PR DESCRIPTION
## Motivation

The results.json was not generated because vegeta was not found. For some reason the error was caught and silenced which made it harder to debug.


## Solution

Added the /home/flood/bin directory to the PATH and make sure the vegeta bin ends up in the right path

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
