### PR TITLE
Docker run from the CI, fixes #34

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,3 +13,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v2
       - run: docker build --tag paradigmxyz/flood:latest .
+      - run: docker run --rm paradigmxyz/flood:latest version
+      - run: |
+          docker run --rm paradigmxyz/flood:latest \
+          eth_getBlockByNumber \
+          node1=https://eth.llamarpc.com \
+          node2=https://eth.llamarpc.com \
+          --duration 3 --rate 1

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 ![](./assets/cover.png)
 
 [![CI status](https://github.com/paradigmxyz/flood/workflows/Pytest/badge.svg)][gh-ci]
+[![Docker](https://github.com/paradigmxyz/flood/actions/workflows/docker.yml/badge.svg)][gh-docker]
 [![Telegram Chat][tg-badge]][tg-url]
 
 [gh-ci]: https://github.com/paradigmxyz/flood/actions/workflows/ci.yml
+[gh-docker]: https://github.com/paradigmxyz/flood/actions/workflows/docker.yml
 [tg-badge]: https://img.shields.io/endpoint?color=neon&logo=telegram&label=chat&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Fparadigm%5Fflood
 [tg-url]: https://t.me/paradigm_flood
 


### PR DESCRIPTION
Run a light test agaisnt the llama public RPC.
Note while this is working for now the GitHub runner IPs could get blacklisted as people abuse it. Updating the CI to use an API key would solve it.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/paradigmxyz/flood/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running ruff and building the
documentation.
-->

## Motivation

Catch Docker image runtime issues early

## Solution

Do a docker run from the CI

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
