### PR TITLE
Decrease Docker image size, fixes #33

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,33 @@
-FROM python:3.11.3
-
-# create user
+# Stage 1: Install flood
+FROM python:3.11.3-slim AS flood-builder
 ENV USERNAME="flood"
-ENV PATH="${PATH}:/home/${USERNAME}/bin"
+ENV PATH="${PATH}:/home/${USERNAME}/.local/bin"
 RUN adduser $USERNAME
 USER $USERNAME
 
-# install flood
-RUN mkdir /home/$USERNAME/repos
 COPY ./ /home/$USERNAME/repos/flood/
 WORKDIR /home/$USERNAME/repos/flood
-RUN pip install ./
+RUN pip install --user --no-cache-dir ./
 
-# install vegeta
-RUN mkdir -p /home/$USERNAME/bin/vegeta_files
-WORKDIR /home/$USERNAME/bin/vegeta_files
-RUN wget https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz
-RUN tar xzf vegeta_12.8.4_linux_amd64.tar.gz
-RUN ln -s /home/$USERNAME/bin/vegeta_files/vegeta /home/$USERNAME/bin/vegeta
+# Stage 2: Install vegeta
+FROM debian:stable-slim AS vegeta-builder
+RUN apt-get update && apt-get install -y --no-install-recommends wget ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir /vegeta
+WORKDIR /vegeta
+RUN wget https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz \
+ && tar xzf vegeta_12.8.4_linux_amd64.tar.gz \
+ && rm vegeta_12.8.4_linux_amd64.tar.gz
 
-# run flood
+# Final stage: Combine flood and vegeta
+FROM python:3.11.3-slim
+ENV USERNAME="flood"
+ENV PATH="${PATH}:/home/${USERNAME}/.local/bin"
+RUN adduser $USERNAME
+USER $USERNAME
+
+COPY --from=flood-builder /home/$USERNAME/.local /home/$USERNAME/.local
+COPY --from=vegeta-builder /vegeta/vegeta /home/$USERNAME/bin/vegeta
+
 WORKDIR /home/$USERNAME
 ENTRYPOINT ["python", "-m", "flood"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN adduser $USERNAME
 USER $USERNAME
 
 COPY --from=flood-builder /home/$USERNAME/.local /home/$USERNAME/.local
-COPY --from=vegeta-builder /vegeta/vegeta /home/$USERNAME/bin/vegeta
+COPY --from=vegeta-builder /vegeta/vegeta /home/$USERNAME/.local/bin/vegeta
 
 WORKDIR /home/$USERNAME
 ENTRYPOINT ["python", "-m", "flood"]

--- a/flood/spec.py
+++ b/flood/spec.py
@@ -245,7 +245,7 @@ if typing.TYPE_CHECKING:
         n_invalid_json_errors: typing.Sequence[int]
         n_rpc_errors: typing.Sequence[int]
 
-    RunType = typing.Literal['single_test']
+    RunType = typing.Literal['single_test']  # noqa: F821
     DeepOutput = typing.Literal['raw', 'metrics']
 
     class SingleRunTestPayload(typing.TypedDict):


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/paradigmxyz/flood/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running ruff and building the
documentation.
-->

## Motivation

Reduce the Docker size as referenced in Issue #33 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

1. Use Python 3.11.3-slim rather than Python 3.11.3
2. Implement a multi-stage build process to reduce number of unused files/layers in final image

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes

## Metrics
- Original image = 1.8GB
- Original image with slim Python image = 971 MB
- Multi-stage & slim Python image (this PR) = 726 MB

There also seems to be a decrease in build time with this update although I didn't properly benchmark that.
