### PR TITLE
Fix missing curl binary and update CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,15 +8,18 @@ on:
 
 jobs:
   docker:
+    strategy:
+      matrix:
+        test: ["eth_getBalance", "eth_getBlockByNumber"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v2
       - run: docker build --tag paradigmxyz/flood:latest .
       - run: docker run --rm paradigmxyz/flood:latest version
-      - run: |
+      - name: ${{ matrix.test }}
+        run: |
           docker run --rm paradigmxyz/flood:latest \
-          eth_getBlockByNumber \
+          ${{ matrix.test }} \
           node1=https://eth.llamarpc.com \
-          node2=https://eth.llamarpc.com \
           --duration 3 --rate 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/paradigmxyz/flood/pkgs/container/flood
 
 # Stage 1: Install flood
-FROM python:3.11.3-slim AS flood-builder
+FROM python:3.11-slim AS flood-builder
 ENV USERNAME="flood"
 ENV PATH="${PATH}:/home/${USERNAME}/.local/bin"
 RUN adduser $USERNAME
@@ -14,23 +14,26 @@ RUN pip install --user --no-cache-dir ./
 
 # Stage 2: Install vegeta
 FROM debian:stable-slim AS vegeta-builder
+ENV VEGETA_VERSION=12.8.4
 RUN apt-get update && apt-get install -y --no-install-recommends wget ca-certificates \
  && rm -rf /var/lib/apt/lists/* \
  && mkdir /vegeta
 WORKDIR /vegeta
-RUN wget https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz \
- && tar xzf vegeta_12.8.4_linux_amd64.tar.gz \
- && rm vegeta_12.8.4_linux_amd64.tar.gz
+RUN wget https://github.com/tsenart/vegeta/releases/download/v${VEGETA_VERSION}/vegeta_${VEGETA_VERSION}_linux_amd64.tar.gz \
+ && tar xzf vegeta_${VEGETA_VERSION}_linux_amd64.tar.gz \
+ && rm vegeta_${VEGETA_VERSION}_linux_amd64.tar.gz
 
 # Final stage: Combine flood and vegeta
-FROM python:3.11.3-slim
+FROM python:3.11-slim
 ENV USERNAME="flood"
 ENV PATH="${PATH}:/home/${USERNAME}/.local/bin"
 RUN adduser $USERNAME
-USER $USERNAME
 
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+ && rm -rf /var/lib/apt/lists/*
 COPY --from=flood-builder /home/$USERNAME/.local /home/$USERNAME/.local
 COPY --from=vegeta-builder /vegeta/vegeta /home/$USERNAME/.local/bin/vegeta
 
+USER $USERNAME
 WORKDIR /home/$USERNAME
 ENTRYPOINT ["python", "-m", "flood"]


### PR DESCRIPTION
## Commit summary
Fix parquet file download error because of a missing curl binary. This was happening on the `eth_getBalance` test for instance. Note that flood swalled the exception making the error harder to spot.

Update the CI to also test against eth_getBalance which triggers a parquet file download.
Also removes the redundant node2, this was a workaround as flood used to crash with only one node.

Also unpin the patch version of Python and address a small DRY on the Vegeta version.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/paradigmxyz/flood/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running ruff and building the
documentation.
-->

## Motivation

As in version 0.3.1, eth_getBalance fails in a docker environment:
```sh
docker run --rm paradigmxyz/flood:latest eth_getBalance node1=https://eth.llamarpc.com --duration 3 --rate 1
```
Output:
```
┌───────────────────────────┐
│ Load test: eth_getBalance │
└───────────────────────────┘
- sample rates: [1]
- sample duration: 3
- extra args: None
- output directory: /tmp/tmpsrenaj0e

Gathering node data...
──────────────────────
[WARNING] ctc config file does not exist; use `ctc setup` on command line to generate a config file

       node  │                       url  │               metadata  
    ─────────┼────────────────────────────┼─────────────────────────
      node1  │  https://eth.llamarpc.com  │  llamanodes_web3_proxy  
             │                            │               v1.42.11  


Running load tests...
─────────────────────
[2023-08-30 20:37:24] Starting
[2023-08-30 20:37:24] Running load test for node1
/home/flood/.local/lib/python3.11/site-packages/flood/generators/raw_data_sources/raw_download_utils.py:68: UserWarning: FLOOD_SAMPLES_DIR not set in env, defaulting to CWD
  warnings.warn('FLOOD_SAMPLES_DIR not set in env, defaulting to CWD')
downloading ethereum_contracts_samples__L__v1_0_0.parquet

downloading https://datasets.paradigm.xyz/evm_samples/ethereum_samples__v1_0_0/ethereum_contracts_samples__L__v1_0_0.parquet
2
```

## Solution

Fix parquet file download error because of a missing curl binary. This was happening on the `eth_getBalance` test for instance. Note that flood swallowed the exception making the error harder to spot.

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
