### PR TITLE
fix eth_feeHistory during equality tests

### DIFF
--- a/flood/tests/equality_tests/equality_test_sets.py
+++ b/flood/tests/equality_tests/equality_test_sets.py
@@ -166,8 +166,8 @@ def get_vanilla_equality_tests(
             'eth_feeHistory',
             ctc.rpc.construct_eth_fee_history,
             [
-                512,
                 int(start_block),
+                512,
             ],
             {},
         ),


### PR DESCRIPTION
This PR allows fixing a bug in the equality tests that incorrectly builds eth_feeHistory.
we should inverse value as we are doing here https://github.com/paradigmxyz/flood/blob/03f93c494d2cf29e96a6914c1575fac745cba001/flood/generators/object_generators/call_generators.py#L90

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
