### PR TITLE
Add possibility to filter equality tests based on RegExp

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ Instead of testing the raw performance of an RPC node, `flood` can be used to te
 
 `flood all reth=91.91.91.91 erigon=92.92.92.92 --equality`
 
+There is a possibility to run only specific test or a subset of tests using regular expression like this:
+
+`flood debug_* reth=91.91.91.91 erigon=92.92.92.92 --equality`
+
+Above will run all the test scenarios which contain prefix "debug_".
+
 ### From python
 
 All of `flood`'s functionality can be used from python instead of the CLI. Some functions:

--- a/flood/tests/equality_tests/equality_test_runs.py
+++ b/flood/tests/equality_tests/equality_test_runs.py
@@ -18,6 +18,7 @@ def run_equality_test(
     import os
     import requests
     import toolstr
+    import re
 
     nodes = flood.user_io.parse_nodes(nodes, request_metadata=True)
     for node in nodes.values():
@@ -30,7 +31,8 @@ def run_equality_test(
 
     # get tests
     if test_name != 'all':
-        equality_tests = [t for t in equality_tests if t[0] == test_name]
+        pattern = f"^{test_name}"  # Creates a regex pattern starting with test_name
+        equality_tests = [t for t in equality_tests if re.match(pattern, t[0])]
         if not equality_tests:
             raise NotImplementedError(
                 'no matching test found for name "' + test_name + '"'


### PR DESCRIPTION
## Motivation

I want to run only specific subset of tests for example:
1.  Compare Nethermind and Erigon where erigon does have trace_*
2. Compare Nethermind and Geth where geth do not have trace_* module.

This change allows me to split the runs for Geth and Erigon

## Solution

Just simply give an opportunity to pass regexp patter to testname.
Works as usual for all and for specific test.
For pattern it looks like this:
<img width="616" alt="image" src="https://github.com/paradigmxyz/flood/assets/43241881/14b111a0-fd00-4e50-8db9-09f2613a7d08">

## PR Checklist

-   [ ] Added Tests -> Not yet, if needed I can add them but I see for equality currently there is only one.
-   [ ] Added Documentation -> Will add in next commit
-   [ ] Breaking changes -> None
